### PR TITLE
Fix H1310 ceiling-fan light controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 - fix: give the H1310 and R1310 ceiling fans their own handler, with the light they were missing (#1352)
 - fix: scale the H1310 and R1310 fan speed to the six steps they have, not the H1370's twelve (#1352)
 - fix: stop a fan ignoring the first speed asked of it after a restart
+- chore: log what each govee capability accepts, not only that it exists, in debug mode
 
 ## v11.36.0 (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 - fix: stop a fan ignoring the first speed asked of it after a restart
 - chore: log what each govee capability accepts, not only that it exists, in debug mode
 - fix: take a ceiling fan's speed count from the fan itself, rather than from its model (#1352)
+- fix: send the H1310 and R1310 brightness on the scale they accept, so the light stops landing at a third (#1352)
 
 ## v11.36.0 (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 
 - fix: give the H1310 and R1310 ceiling fans their own handler, with the light they were missing (#1352)
 - fix: scale the H1310 and R1310 fan speed to the six steps they have, not the H1370's twelve (#1352)
+- fix: stop a fan ignoring the first speed asked of it after a restart
 
 ## v11.36.0 (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 - chore: log what each govee capability accepts, not only that it exists, in debug mode
 - fix: take a ceiling fan's speed count from the fan itself, rather than from its model (#1352)
 - fix: send the H1310 and R1310 brightness on the scale they accept, so the light stops landing at a third (#1352)
+- fix: stop reporting success for a command sent on a connection the device does not have enabled
 
 ## v11.36.0 (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `@homebridge-plugins/homebridge-govee` will be documented in this file.
 
+## v11.36.1 (Pending Release)
+
+### Changed
+
+- fix: give the H1310 and R1310 ceiling fans their own handler, with the light they were missing (#1352)
+
 ## v11.36.0 (2026-08-11)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 - fix: scale the H1310 and R1310 fan speed to the six steps they have, not the H1370's twelve (#1352)
 - fix: stop a fan ignoring the first speed asked of it after a restart
 - chore: log what each govee capability accepts, not only that it exists, in debug mode
+- fix: take a ceiling fan's speed count from the fan itself, rather than from its model (#1352)
 
 ## v11.36.0 (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `@homebridge-plugins/homebridge-govee` will be documented
 ### Changed
 
 - fix: give the H1310 and R1310 ceiling fans their own handler, with the light they were missing (#1352)
+- fix: scale the H1310 and R1310 fan speed to the six steps they have, not the H1370's twelve (#1352)
 
 ## v11.36.0 (2026-08-11)
 

--- a/lib/device/fan-H1310.js
+++ b/lib/device/fan-H1310.js
@@ -58,10 +58,28 @@ export default class GoveeFanH1310 extends deviceFanH1370 {
       return
     }
 
-    await this.platform.sendDeviceUpdate(this.accessory, {
-      cmd: 'state',
-      value: newValue,
-    })
+    // Map the human-friendly service name to the OpenAPI instance name the
+    // platform recognises for per-light toggles.
+    const instance = name === 'Main Light' ? 'mainLightToggle' : 'backgroundLightToggle'
+
+    // Prefer the OpenAPI per-light toggle if the capability is present and the
+    // platform is able to use it; otherwise fall back to the device-wide state
+    // command so behaviour remains unchanged on older setups.
+    if (this.accessory.context.openApiCapabilities?.[instance] && this.accessory.context.useOpenApiControl) {
+      await this.platform.sendDeviceUpdate(this.accessory, {
+        cmd: 'openApi',
+        openApi: {
+          instance,
+          capabilityType: 'devices.capabilities.toggle',
+          value: newValue === 'on' ? 1 : 0,
+        },
+      })
+    } else {
+      await this.platform.sendDeviceUpdate(this.accessory, {
+        cmd: 'state',
+        value: newValue,
+      })
+    }
 
     this[cacheKey] = newValue
     this.accessory.log(`${name} ${newValue}`)

--- a/lib/device/fan-H1310.js
+++ b/lib/device/fan-H1310.js
@@ -10,6 +10,15 @@ export default class GoveeFanH1310 extends deviceFanH1370 {
     // ceiling-fan range.
     this.speedSteps = 6
 
+    // The superclass (H1370) may have added a default unnamed Lightbulb
+    // service when it initialised the main light. Remove any inherited
+    // unnamed Lightbulb (no subtype) so that only the two named services we
+    // create below appear in Home, avoiding a third unwanted tile.
+    const inheritedLight = this.accessory.getService(this.hapServ.Lightbulb)
+    if (inheritedLight && !inheritedLight.subtype) {
+      this.accessory.removeService(inheritedLight)
+    }
+
     if (this.service.testCharacteristic(this.hapChar.SwingMode)) {
       this.service.removeCharacteristic(this.service.getCharacteristic(this.hapChar.SwingMode))
     }

--- a/lib/device/fan-H1310.js
+++ b/lib/device/fan-H1310.js
@@ -1,0 +1,137 @@
+import { hs2rgb } from '../utils/colour.js'
+import { generateRandomString, sleep } from '../utils/functions.js'
+import deviceFanH1370 from './fan-H1370.js'
+
+export default class GoveeFanH1310 extends deviceFanH1370 {
+  constructor(platform, accessory) {
+    super(platform, accessory)
+
+    // The H1310/R1310 uses a 6-step speed scale instead of the H1370's 12-step
+    // ceiling-fan range.
+    this.speedSteps = 6
+
+    if (this.service.testCharacteristic(this.hapChar.SwingMode)) {
+      this.service.removeCharacteristic(this.service.getCharacteristic(this.hapChar.SwingMode))
+    }
+
+    this.lightServices = {}
+    ;['Main Light', 'Background Light'].forEach((name) => {
+      const service = this.accessory.getService(name)
+        || this.accessory.addService(this.hapServ.Lightbulb, name, name)
+      this.lightServices[name] = service
+      this.setupLightService(service, name)
+    })
+  }
+
+  setupLightService(service, name) {
+    service.getCharacteristic(this.hapChar.On).onSet(async (value) => {
+      await this.internalLightStateUpdate(service, name, value)
+    })
+
+    service
+      .getCharacteristic(this.hapChar.Brightness)
+      .setProps({ minStep: 1 })
+      .onSet(async (value) => {
+        await this.internalBrightnessUpdate(service, name, value)
+      })
+
+    service.getCharacteristic(this.hapChar.Hue).onSet(async (value) => {
+      await this.internalColourUpdate(service, name, value)
+    })
+
+    service.getCharacteristic(this.hapChar.Saturation).onSet(async () => {
+      await this.internalColourUpdate(service, name, service.getCharacteristic(this.hapChar.Hue).value)
+    })
+
+    if (!service.testCharacteristic(this.hapChar.ColorTemperature)) {
+      service.addCharacteristic(this.hapChar.ColorTemperature)
+    }
+    service.getCharacteristic(this.hapChar.ColorTemperature).onSet(async (value) => {
+      await this.internalCTUpdate(service, name, value)
+    })
+  }
+
+  async internalLightStateUpdate(service, name, value) {
+    const newValue = value ? 'on' : 'off'
+    const cacheKey = `${name}:state`
+    if (this[cacheKey] === newValue) {
+      return
+    }
+
+    await this.platform.sendDeviceUpdate(this.accessory, {
+      cmd: 'state',
+      value: newValue,
+    })
+
+    this[cacheKey] = newValue
+    this.accessory.log(`${name} ${newValue}`)
+  }
+
+  async internalBrightnessUpdate(service, name, value) {
+    const updateKey = generateRandomString(5)
+    this[`${name}:updateKeyBright`] = updateKey
+    await sleep(350)
+    if (updateKey !== this[`${name}:updateKeyBright`]) {
+      return
+    }
+
+    const cacheKey = `${name}:brightness`
+    if (this[cacheKey] === value) {
+      return
+    }
+
+    await this.platform.sendDeviceUpdate(this.accessory, {
+      cmd: 'brightness',
+      value,
+    })
+
+    this[cacheKey] = value
+    this.accessory.log(`${name} brightness [${value}%]`)
+  }
+
+  async internalColourUpdate(service, name, hue) {
+    const updateKey = generateRandomString(5)
+    this[`${name}:updateKeyColour`] = updateKey
+    await sleep(300)
+    if (updateKey !== this[`${name}:updateKeyColour`]) {
+      return
+    }
+
+    const sat = service.getCharacteristic(this.hapChar.Saturation).value
+    const [r, g, b] = hs2rgb(hue, sat)
+    const cacheKey = `${name}:colour`
+    if (this[cacheKey] && this[cacheKey].r === r && this[cacheKey].g === g && this[cacheKey].b === b) {
+      return
+    }
+
+    await this.platform.sendDeviceUpdate(this.accessory, {
+      cmd: 'color',
+      value: { r, g, b },
+    })
+
+    this[cacheKey] = { r, g, b, hue, sat }
+    this.accessory.log(`${name} colour [rgb ${r} ${g} ${b}]`)
+  }
+
+  async internalCTUpdate(service, name, value) {
+    const updateKey = generateRandomString(5)
+    this[`${name}:updateKeyCT`] = updateKey
+    await sleep(300)
+    if (updateKey !== this[`${name}:updateKeyCT`]) {
+      return
+    }
+
+    const cacheKey = `${name}:ct`
+    if (this[cacheKey] === value) {
+      return
+    }
+
+    await this.platform.sendDeviceUpdate(this.accessory, {
+      cmd: 'colorTem',
+      value,
+    })
+
+    this[cacheKey] = value
+    this.accessory.log(`${name} colour temperature [${value}M]`)
+  }
+}

--- a/lib/device/fan-H1310.js
+++ b/lib/device/fan-H1310.js
@@ -7,8 +7,8 @@ export default class GoveeFanH1310 extends deviceFanH1370 {
     super(platform, accessory)
 
     // The H1310/R1310 uses a 6-step speed scale instead of the H1370's 12-step
-    // ceiling-fan range.
-    this.speedSteps = 6
+    // ceiling-fan range. (speedSteps now comes from device-capabilities or the
+    // device's OpenAPI fanSpeedMode; do not overwrite the superclass value here.)
 
     // The superclass (H1370) may have added a default unnamed Lightbulb
     // service when it initialised the main light. Remove any inherited

--- a/lib/device/fan-H1370.js
+++ b/lib/device/fan-H1370.js
@@ -1,6 +1,7 @@
 import { getDeviceCapabilities } from '../utils/device-capabilities.js'
 import {
   base64ToHex,
+  fanSpeedStepsFrom,
   fanSpeedToHkPercent,
   generateCodeFromHexValues,
   generateRandomString,
@@ -51,8 +52,12 @@ export default class GoveeFanH1370 extends GoveeDevice {
     this.cacheState = this.service.getCharacteristic(this.hapChar.Active).value ? 'on' : 'off'
 
     // Real speed steps - HomeKit percentages map onto these, and they differ
-    // per model, so the scale comes from the capabilities table
-    this.speedSteps = getDeviceCapabilities(accessory.context.gvModel).fanSpeedSteps
+    // per model. The fan's own api entry is the best answer where there is one,
+    // with the model table behind it for a device the api never described
+    this.speedSteps = fanSpeedStepsFrom(
+      accessory.context.openApiCapabilities,
+      getDeviceCapabilities(accessory.context.gvModel).fanSpeedSteps,
+    )
 
     // Add the set handler to the fan rotation speed characteristic
     this.service

--- a/lib/device/fan-H1370.js
+++ b/lib/device/fan-H1370.js
@@ -64,7 +64,13 @@ export default class GoveeFanH1370 extends GoveeDevice {
         unit: 'unitless',
       })
       .onSet(async value => this.internalSpeedUpdate(value))
-    this.cacheSpeed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+
+    // cacheSpeed holds a device speed step everywhere else, but the restored
+    // characteristic is a HomeKit percentage, so it has to be converted back.
+    // Left as a percentage it would sometimes equal a real step and silently
+    // swallow the first speed the owner asked for.
+    const restoredPercent = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+    this.cacheSpeed = restoredPercent ? hkPercentToFanSpeed(restoredPercent, this.speedSteps) : 0
 
     if (this.hideLight) {
       if (this.accessory.getService(this.hapServ.Lightbulb)) {

--- a/lib/device/fan-H1370.js
+++ b/lib/device/fan-H1370.js
@@ -20,7 +20,7 @@ import GoveeDevice from './base.js'
   The light reports through the standard state/brightness/kelvin fields
   (colour temperature only, 2700-6500K)
 */
-export default class extends GoveeDevice {
+export default class GoveeFanH1370 extends GoveeDevice {
   constructor(platform, accessory) {
     super(platform, accessory)
     // Set up custom variables for this device type

--- a/lib/device/fan-H1370.js
+++ b/lib/device/fan-H1370.js
@@ -1,3 +1,4 @@
+import { getDeviceCapabilities } from '../utils/device-capabilities.js'
 import {
   base64ToHex,
   fanSpeedToHkPercent,
@@ -15,10 +16,13 @@ import GoveeDevice from './base.js'
 /*
   Codes below were decoded from a real device's AWS status reports in
   https://github.com/homebridge-plugins/homebridge-govee/issues/1307
-  Status aa 31 01 [speed] = fan speed (1-12)
+  Status aa 31 01 [speed] = fan speed (1 to the model's step count)
   Status aa 36 01 01 / aa 36 00 00 = fan power on/off
   The light reports through the standard state/brightness/kelvin fields
   (colour temperature only, 2700-6500K)
+
+  The H1310 and R1310 share this handler. They report six speeds against the
+  H1370's twelve, so the scale comes from the capabilities table (#1352)
 */
 export default class GoveeFanH1370 extends GoveeDevice {
   constructor(platform, accessory) {
@@ -46,8 +50,9 @@ export default class GoveeFanH1370 extends GoveeDevice {
       .onSet(async value => this.internalStateUpdate(value))
     this.cacheState = this.service.getCharacteristic(this.hapChar.Active).value ? 'on' : 'off'
 
-    // Real speed steps - HomeKit percentages map onto these
-    this.speedSteps = 12
+    // Real speed steps - HomeKit percentages map onto these, and they differ
+    // per model, so the scale comes from the capabilities table
+    this.speedSteps = getDeviceCapabilities(accessory.context.gvModel).fanSpeedSteps
 
     // Add the set handler to the fan rotation speed characteristic
     this.service

--- a/lib/device/fan-H1370.test.js
+++ b/lib/device/fan-H1370.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resetReportedUnknowns } from '../utils/report-unknown.js'
 import deviceFanH1370 from './fan-H1370.js'
+import deviceFanH1310 from './fan-H1310.js'
 import deviceIndex from './index.js'
 
 /**
@@ -36,16 +37,18 @@ function makeService() {
     onSet() {
       return this
     },
-    onGet() {
-      return this
-    },
     setProps() {
       return this
     },
-    props: {},
   })
   return {
     getCharacteristic(name) {
+      if (!chars.has(name)) {
+        chars.set(name, characteristic(name))
+      }
+      return chars.get(name)
+    },
+    addCharacteristic(name) {
       if (!chars.has(name)) {
         chars.set(name, characteristic(name))
       }
@@ -56,7 +59,11 @@ function makeService() {
       return this
     },
     testCharacteristic: name => chars.has(name),
-    removeCharacteristic() {},
+    removeCharacteristic(char) {
+      if (char) {
+        chars.delete(char.name)
+      }
+    },
     chars,
   }
 }
@@ -72,23 +79,35 @@ function makePlatform() {
 
 function makeAccessory(model) {
   const services = new Map()
+  const bySubtype = new Map()
   return {
     displayName: model,
     context: { gvModel: model, gvDeviceId: 'AA:BB' },
-    getService: name => services.get(name),
-    addService(name) {
+    getService: name => services.get(name) || [...services.values()].find(service => service.displayName === name),
+    getServiceById(type, subtype) {
+      return bySubtype.get(`${type}:${subtype}`)
+    },
+    addService(type, name, subtype) {
       const service = makeService()
-      service.name = name
-      services.set(name, service)
+      service.type = type
+      service.subtype = subtype || name
+      service.name = name || type
+      service.displayName = name || type
+      services.set(name || type, service)
+      if (subtype) {
+        bySubtype.set(`${type}:${subtype}`, service)
+      }
       return service
     },
     removeService(service) {
       services.delete(service.name)
+      if (service.subtype) {
+        bySubtype.delete(`${service.type}:${service.subtype}`)
+      }
     },
     log: vi.fn(),
     logWarn: vi.fn(),
     logDebug: vi.fn(),
-    services,
   }
 }
 
@@ -98,7 +117,11 @@ describe('the ceiling fans', () => {
   })
 
   it.each(['H1310', 'R1310', 'H1370'])('sends the %s to the ceiling fan handler', (model) => {
-    expect(deviceIndex[`deviceFan${model}`]).toBe(deviceFanH1370)
+    if (model === 'H1370') {
+      expect(deviceIndex[`deviceFan${model}`]).toBe(deviceFanH1370)
+    } else {
+      expect(deviceIndex[`deviceFan${model}`]).toBe(deviceFanH1310)
+    }
   })
 
   it.each(['H1310', 'R1310'])('gives the %s a light, which the tower fan handler never did', (model) => {

--- a/lib/device/fan-H1370.test.js
+++ b/lib/device/fan-H1370.test.js
@@ -23,6 +23,10 @@ import deviceIndex from './index.js'
 const FAN_POWER_OFF = 'qjYAAAAAAAAAAAAAAAAAAAAAAJw='
 // aa 31 01 01 - fan speed 1
 const FAN_SPEED_1 = 'qjEBAQAAAAAAAAAAAAAAAAAAAJs='
+// aa 31 01 06 - fan speed 6, the top speed on an H1310
+const FAN_SPEED_6 = 'qjEBBgAAAAAAAAAAAAAAAAAAAJw='
+// aa 31 01 0c - fan speed 12, the top speed on an H1370
+const FAN_SPEED_12 = 'qjEBDAAAAAAAAAAAAAAAAAAAAJY='
 
 function makeService() {
   const chars = new Map()
@@ -127,6 +131,43 @@ describe('the ceiling fans', () => {
 
     expect(device.cacheSpeed).toBeGreaterThan(0)
   })
+
+  /**
+   * The H1310's owner counted six speeds in the Govee app, against the twelve
+   * the H1370 was written for. Sharing one scale left the slider wrong at both
+   * ends: the fan's top speed showed as half, and asking for full speed sent a
+   * step the fan does not have (#1352).
+   */
+  it.each([['H1310', 6], ['R1310', 6], ['H1370', 12]])('gives the %s its own %i speed steps', (model, steps) => {
+    const device = new deviceIndex[`deviceFan${model}`](makePlatform(), makeAccessory(model))
+
+    expect(device.speedSteps).toBe(steps)
+  })
+
+  it.each([['H1310', FAN_SPEED_6], ['R1310', FAN_SPEED_6], ['H1370', FAN_SPEED_12]])(
+    'shows the %s at its top speed as 100% in HomeKit',
+    (model, topSpeedFrame) => {
+      const accessory = makeAccessory(model)
+      const device = new deviceIndex[`deviceFan${model}`](makePlatform(), accessory)
+
+      device.externalUpdate({ commands: [topSpeedFrame], source: 'AWS' })
+
+      expect(accessory.services.get('Fanv2').getCharacteristic('RotationSpeed').value).toBe(100)
+    },
+  )
+
+  it.each([['H1310', 6], ['R1310', 6], ['H1370', 12]])(
+    'asks the %s for speed %i when HomeKit is set to 100%',
+    async (model, topSpeed) => {
+      const device = new deviceIndex[`deviceFan${model}`](makePlatform(), makeAccessory(model))
+      const sent = []
+      device.platform.sendDeviceUpdate = async (_accessory, params) => sent.push(params)
+
+      await device.internalSpeedUpdate(100)
+
+      expect(device.cacheSpeed).toBe(topSpeed)
+    },
+  )
 
   /**
    * The two frames above were arriving as "unrecognised status" lines on the

--- a/lib/device/fan-H1370.test.js
+++ b/lib/device/fan-H1370.test.js
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resetReportedUnknowns } from '../utils/report-unknown.js'
-import deviceFanH1370 from './fan-H1370.js'
 import deviceFanH1310 from './fan-H1310.js'
+import deviceFanH1370 from './fan-H1370.js'
 import deviceIndex from './index.js'
 
 /**

--- a/lib/device/fan-H1370.test.js
+++ b/lib/device/fan-H1370.test.js
@@ -144,6 +144,38 @@ describe('the ceiling fans', () => {
     expect(device.speedSteps).toBe(steps)
   })
 
+  /**
+   * Govee's api lists a fan's speeds per device, so it beats the model table -
+   * it is right for a model nobody has written down, and it settles a handler
+   * shared by two models with different counts. These options are the ones an
+   * H1310 reported in #1352.
+   */
+  it('takes the speed count from the fan rather than the model table', () => {
+    const accessory = makeAccessory('H1370')
+    accessory.context.openApiCapabilities = {
+      fanSpeedMode: {
+        type: 'devices.capabilities.mode',
+        instance: 'fanSpeedMode',
+        parameters: {
+          dataType: 'ENUM',
+          options: Array.from({ length: 6 }, (_, index) => ({ name: `Speed ${index + 1}`, value: index + 1 })),
+        },
+      },
+    }
+    const device = new deviceIndex.deviceFanH1370(makePlatform(), accessory)
+
+    // the table says twelve for an H1370, the fan says six
+    expect(device.speedSteps).toBe(6)
+  })
+
+  it('keeps the model table when the api described no speeds', () => {
+    const accessory = makeAccessory('H1370')
+    accessory.context.openApiCapabilities = { fanToggle: { parameters: { options: [] } } }
+    const device = new deviceIndex.deviceFanH1370(makePlatform(), accessory)
+
+    expect(device.speedSteps).toBe(12)
+  })
+
   it.each([['H1310', FAN_SPEED_6], ['R1310', FAN_SPEED_6], ['H1370', FAN_SPEED_12]])(
     'shows the %s at its top speed as 100% in HomeKit',
     (model, topSpeedFrame) => {

--- a/lib/device/fan-H1370.test.js
+++ b/lib/device/fan-H1370.test.js
@@ -207,7 +207,7 @@ describe('the ceiling fans', () => {
 
       device.externalUpdate({ commands: [topSpeedFrame], source: 'AWS' })
 
-      expect(accessory.services.get('Fanv2').getCharacteristic('RotationSpeed').value).toBe(100)
+      expect(accessory.getService('Fanv2').getCharacteristic('RotationSpeed').value).toBe(100)
     },
   )
 

--- a/lib/device/fan-H1370.test.js
+++ b/lib/device/fan-H1370.test.js
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetReportedUnknowns } from '../utils/report-unknown.js'
+import deviceFanH1370 from './fan-H1370.js'
+import deviceIndex from './index.js'
+
+/**
+ * The H1310 and R1310 are ceiling fans with lights, and were on the H7100
+ * tower fan handler as "the same fan". They are not the same fan at all -
+ * Govee's own app files them under Indoor Lighting as "Govee Ceiling Fan",
+ * while every H71xx sits under Air Treatment.
+ *
+ * The cost to an owner was all three of the symptoms in #1352: a fan tile that
+ * did nothing, because the tower fan's speed codes mean nothing here; an
+ * oscillation control for a fan that cannot oscillate; and no light at all,
+ * because the H7100 handler never builds one.
+ *
+ * The frames below are from that report, and they are exactly the ones this
+ * handler already reads.
+ */
+
+// aa 36 00 00 - fan power off
+const FAN_POWER_OFF = 'qjYAAAAAAAAAAAAAAAAAAAAAAJw='
+// aa 31 01 01 - fan speed 1
+const FAN_SPEED_1 = 'qjEBAQAAAAAAAAAAAAAAAAAAAJs='
+
+function makeService() {
+  const chars = new Map()
+  const characteristic = name => ({
+    name,
+    value: 0,
+    onSet() {
+      return this
+    },
+    onGet() {
+      return this
+    },
+    setProps() {
+      return this
+    },
+    props: {},
+  })
+  return {
+    getCharacteristic(name) {
+      if (!chars.has(name)) {
+        chars.set(name, characteristic(name))
+      }
+      return chars.get(name)
+    },
+    updateCharacteristic(name, value) {
+      this.getCharacteristic(name).value = value
+      return this
+    },
+    testCharacteristic: name => chars.has(name),
+    removeCharacteristic() {},
+    chars,
+  }
+}
+
+function makePlatform() {
+  const proxy = new Proxy({}, { get: (_target, prop) => prop })
+  return {
+    log: Object.assign(vi.fn(), { warn: vi.fn(), debug: vi.fn() }),
+    api: { hap: { Service: proxy, Characteristic: proxy, HapStatusError: class {} } },
+    deviceConf: {},
+  }
+}
+
+function makeAccessory(model) {
+  const services = new Map()
+  return {
+    displayName: model,
+    context: { gvModel: model, gvDeviceId: 'AA:BB' },
+    getService: name => services.get(name),
+    addService(name) {
+      const service = makeService()
+      service.name = name
+      services.set(name, service)
+      return service
+    },
+    removeService(service) {
+      services.delete(service.name)
+    },
+    log: vi.fn(),
+    logWarn: vi.fn(),
+    logDebug: vi.fn(),
+    services,
+  }
+}
+
+describe('the ceiling fans', () => {
+  beforeEach(() => {
+    resetReportedUnknowns()
+  })
+
+  it.each(['H1310', 'R1310', 'H1370'])('sends the %s to the ceiling fan handler', (model) => {
+    expect(deviceIndex[`deviceFan${model}`]).toBe(deviceFanH1370)
+  })
+
+  it.each(['H1310', 'R1310'])('gives the %s a light, which the tower fan handler never did', (model) => {
+    const accessory = makeAccessory(model)
+    const Handler = deviceIndex[`deviceFan${model}`]
+    const device = new Handler(makePlatform(), accessory)
+
+    expect(device.lightService).toBeTruthy()
+  })
+
+  it.each(['H1310', 'R1310'])('reads the %s fan power its owner actually reported', (model) => {
+    const accessory = makeAccessory(model)
+    const Handler = deviceIndex[`deviceFan${model}`]
+    const device = new Handler(makePlatform(), accessory)
+
+    // start from on, so the frame has to genuinely move it rather than the
+    // assertion landing on whatever the cache happened to start as
+    device.cacheState = 'on'
+    device.externalUpdate({ commands: [FAN_POWER_OFF], source: 'AWS' })
+
+    expect(device.cacheState).toBe('off')
+  })
+
+  it.each(['H1310', 'R1310'])('reads the %s fan speed its owner actually reported', (model) => {
+    const accessory = makeAccessory(model)
+    const Handler = deviceIndex[`deviceFan${model}`]
+    const device = new Handler(makePlatform(), accessory)
+
+    device.externalUpdate({ commands: [FAN_SPEED_1], source: 'AWS' })
+
+    expect(device.cacheSpeed).toBeGreaterThan(0)
+  })
+
+  /**
+   * The two frames above were arriving as "unrecognised status" lines on the
+   * old handler, which is what sent the owner to the issue tracker.
+   */
+  it.each(['H1310', 'R1310'])('no longer calls the %s fan frames unrecognised', (model) => {
+    const accessory = makeAccessory(model)
+    const Handler = deviceIndex[`deviceFan${model}`]
+    const device = new Handler(makePlatform(), accessory)
+
+    device.externalUpdate({ commands: [FAN_POWER_OFF, FAN_SPEED_1], source: 'AWS' })
+
+    const said = [
+      ...accessory.logWarn.mock.calls,
+      ...accessory.logDebug.mock.calls,
+    ].map(call => String(call[0])).join(' ')
+    expect(said).not.toMatch(/unrecognised/)
+  })
+})

--- a/lib/device/fan-H7100.js
+++ b/lib/device/fan-H7100.js
@@ -78,7 +78,15 @@ export default class GoveeFanH7100 extends GoveeDevice {
         unit: 'unitless',
       })
       .onSet(async value => this.internalSpeedUpdate(value))
-    this.cacheSpeed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+
+    // cacheSpeed holds a device speed step everywhere else, but the restored
+    // characteristic is a HomeKit percentage, so it has to be converted back.
+    // Left as a percentage it would sometimes equal a real step and silently
+    // swallow the first speed the owner asked for. A restored 100% stays
+    // ambiguous between auto and top speed - both report 100 - so it settles on
+    // top speed rather than guessing.
+    const restoredPercent = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+    this.cacheSpeed = restoredPercent ? hkPercentToFanSpeed(restoredPercent, this.speedSteps) : 0
 
     // Add the set handler to the fan swing mode
     this.service

--- a/lib/device/fan-H7100.js
+++ b/lib/device/fan-H7100.js
@@ -75,7 +75,9 @@ export default class GoveeFanH7100 extends GoveeDevice {
         unit: 'unitless',
       })
       .onSet(async value => this.internalSpeedUpdate(value))
-    this.cacheSpeed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+    // Seed the cache from any restored percentage using the model's speed steps
+    const restoredPercent = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+    this.cacheSpeed = restoredPercent ? hkPercentToFanSpeed(restoredPercent, this.speedSteps) : 0
 
     // Add the set handler to the fan swing mode
     this.service

--- a/lib/device/fan-H7100.js
+++ b/lib/device/fan-H7100.js
@@ -16,8 +16,9 @@ import GoveeDevice from './base.js'
   H7100, H7102, H7106 -> Sleep, Nature, Custom, Auto
   H7101               -> Sleep, Nature, Turbo, Custom, Auto
   H7111               -> Sleep, Nature, Custom, Auto
-  H1310, R1310        -> as the H7100, but its oscillation status message has
-                         never been confirmed, so it is not read back
+
+  The H1310 and R1310 were once on this handler as "the same fan". They are
+  not - they are ceiling fans with lights, and moved to fan-H1370 in #1352.
  */
 
 export default class GoveeFanH7100 extends GoveeDevice {

--- a/lib/device/fan-H7100.js
+++ b/lib/device/fan-H7100.js
@@ -11,14 +11,11 @@ import { logUnknownData } from '../utils/report-unknown.js'
 import GoveeDevice from './base.js'
 
 /*
-  The models on this handler and the modes each offers:
+ The models on this handler and the modes each offers:
 
-  H7100, H7102, H7106 -> Sleep, Nature, Custom, Auto
-  H7101               -> Sleep, Nature, Turbo, Custom, Auto
-  H7111               -> Sleep, Nature, Custom, Auto
-
-  The H1310 and R1310 were once on this handler as "the same fan". They are
-  not - they are ceiling fans with lights, and moved to fan-H1370 in #1352.
+ H7100, H7102, H7106 -> Sleep, Nature, Custom, Auto
+ H7101               -> Sleep, Nature, Turbo, Custom, Auto
+ H7111               -> Sleep, Nature, Custom, Auto
  */
 
 export default class GoveeFanH7100 extends GoveeDevice {
@@ -78,15 +75,7 @@ export default class GoveeFanH7100 extends GoveeDevice {
         unit: 'unitless',
       })
       .onSet(async value => this.internalSpeedUpdate(value))
-
-    // cacheSpeed holds a device speed step everywhere else, but the restored
-    // characteristic is a HomeKit percentage, so it has to be converted back.
-    // Left as a percentage it would sometimes equal a real step and silently
-    // swallow the first speed the owner asked for. A restored 100% stays
-    // ambiguous between auto and top speed - both report 100 - so it settles on
-    // top speed rather than guessing.
-    const restoredPercent = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
-    this.cacheSpeed = restoredPercent ? hkPercentToFanSpeed(restoredPercent, this.speedSteps) : 0
+    this.cacheSpeed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
 
     // Add the set handler to the fan swing mode
     this.service

--- a/lib/device/fan-H7100.test.js
+++ b/lib/device/fan-H7100.test.js
@@ -4,11 +4,9 @@ import { resetReportedUnknowns } from '../utils/report-unknown.js'
 import deviceFanH7100 from './fan-H7100.js'
 
 /**
- * The H1310 and R1310 ceiling fans share this handler, but their oscillation
- * status message has never been confirmed to mean the same thing, so they are
- * set not to read it. That difference is data rather than a second copy of the
- * file, and the model snapshot cannot see it - it only covers which controls a
- * device is given, not how it reads messages back. So it is pinned here.
+ * Oscillation read-back for the tower fans on this handler. The H1310 and
+ * R1310 used to be here too, opted out of reading it; they turned out to be
+ * ceiling fans and moved to fan-H1370 (#1352).
  */
 
 const SWING_ON_STATUS = 'qh8BAQAAAAAAAAAAAAAAAAAAALU='
@@ -85,29 +83,5 @@ describe('reading a fan\'s oscillation status', () => {
 
     expect(device.cacheSwing).toBe('on')
     expect(device.service.getCharacteristic('SwingMode').value).toBe(1)
-  })
-
-  it('reports the message instead on a model where it is not confirmed', () => {
-    const accessory = makeAccessory('H1310')
-    const device = new deviceFanH7100(makePlatform(), accessory)
-
-    device.externalUpdate({ commands: [SWING_ON_STATUS], source: 'AWS' })
-
-    expect(device.cacheSwing).not.toBe('on')
-    // recorded rather than shouted about: the fan volunteered this, and the
-    // owner cannot act on it - but the model has to stay in the line
-    expect(accessory.logDebug).toHaveBeenCalled()
-    expect(accessory.logDebug.mock.calls.map(call => call[0]).join(' ')).toContain('H1310')
-  })
-
-  it('treats the R1310 the same as the H1310', () => {
-    // Same fan under a newer name, so it must not quietly behave differently
-    const accessory = makeAccessory('R1310')
-    const device = new deviceFanH7100(makePlatform(), accessory)
-
-    device.externalUpdate({ commands: [SWING_ON_STATUS], source: 'AWS' })
-
-    expect(device.cacheSwing).not.toBe('on')
-    expect(accessory.logDebug.mock.calls.map(call => call[0]).join(' ')).toContain('R1310')
   })
 })

--- a/lib/device/fan-H7100.test.js
+++ b/lib/device/fan-H7100.test.js
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getDeviceCapabilities } from '../utils/device-capabilities.js'
 import { resetReportedUnknowns } from '../utils/report-unknown.js'
+import deviceFanH1310 from './fan-H1310.js'
 import deviceFanH7100 from './fan-H7100.js'
 
 /**
- * Oscillation read-back for the tower fans on this handler. The H1310 and
- * R1310 used to be here too, opted out of reading it; they turned out to be
- * ceiling fans and moved to fan-H1370 (#1352).
+ * The H1310 and R1310 ceiling fans still do not have a confirmed oscillation
+ * status meaning, so they are left with the readback disabled even though they
+ * have their own handler. That difference is model data rather than a second
+ * copy of the file, and the model snapshot cannot see it - it only covers which
+ * controls a device is given, not how it reads messages back. So it is pinned
+ * here.
  */
 
 const SWING_ON_STATUS = 'qh8BAQAAAAAAAAAAAAAAAAAAALU='
@@ -30,12 +35,22 @@ function makeService() {
       }
       return chars.get(name)
     },
+    addCharacteristic(name) {
+      if (!chars.has(name)) {
+        chars.set(name, characteristic(name))
+      }
+      return chars.get(name)
+    },
     updateCharacteristic(name, value) {
       this.getCharacteristic(name).value = value
       return this
     },
     testCharacteristic: name => chars.has(name),
-    removeCharacteristic() {},
+    removeCharacteristic(char) {
+      if (char) {
+        chars.delete(char.name)
+      }
+    },
     chars,
   }
 }
@@ -51,18 +66,31 @@ function makePlatform() {
 
 function makeAccessory(model) {
   const services = new Map()
+  const bySubtype = new Map()
   return {
     displayName: model,
     context: { gvModel: model, gvDeviceId: 'AA:BB' },
-    getService: name => services.get(name),
-    addService(name) {
+    getService: name => services.get(name) || [...services.values()].find(service => service.displayName === name),
+    getServiceById(type, subtype) {
+      return bySubtype.get(`${type}:${subtype}`)
+    },
+    addService(type, name, subtype) {
       const service = makeService()
-      service.name = name
-      services.set(name, service)
+      service.type = type
+      service.subtype = subtype || name
+      service.name = name || type
+      service.displayName = name || type
+      services.set(name || type, service)
+      if (subtype) {
+        bySubtype.set(`${type}:${subtype}`, service)
+      }
       return service
     },
     removeService(service) {
       services.delete(service.name)
+      if (service.subtype) {
+        bySubtype.delete(`${service.type}:${service.subtype}`)
+      }
     },
     log: vi.fn(),
     logWarn: vi.fn(),
@@ -84,4 +112,49 @@ describe('reading a fan\'s oscillation status', () => {
     expect(device.cacheSwing).toBe('on')
     expect(device.service.getCharacteristic('SwingMode').value).toBe(1)
   })
+
+  it('reports the message instead on a model where it is not confirmed', () => {
+    const accessory = makeAccessory('H1310')
+    const device = new deviceFanH7100(makePlatform(), accessory)
+
+    device.externalUpdate({ commands: [SWING_ON_STATUS], source: 'AWS' })
+
+    expect(device.cacheSwing).not.toBe('on')
+    // recorded rather than shouted about: the fan volunteered this, and the
+    // owner cannot act on it - but the model has to stay in the line
+    expect(accessory.logDebug).toHaveBeenCalled()
+    expect(accessory.logDebug.mock.calls.map(call => call[0]).join(' ')).toContain('H1310')
+  })
+
+  it('treats the R1310 the same as the H1310', () => {
+    // Same fan under a newer name, so it must not quietly behave differently
+    const accessory = makeAccessory('R1310')
+    const device = new deviceFanH7100(makePlatform(), accessory)
+
+    device.externalUpdate({ commands: [SWING_ON_STATUS], source: 'AWS' })
+
+    expect(device.cacheSwing).not.toBe('on')
+    expect(accessory.logDebug.mock.calls.map(call => call[0]).join(' ')).toContain('R1310')
+  })
+
+  it('uses the H1310 model-specific fan and brightness settings', () => {
+    const accessory = makeAccessory('H1310')
+    const device = new deviceFanH1310(makePlatform(), accessory)
+    const main = discoverService(accessory, 'Main Light')
+    const background = discoverService(accessory, 'Background Light')
+
+    expect(main).toBeDefined()
+    expect(background).toBeDefined()
+    expect(main.getCharacteristic('Hue')).toBeDefined()
+    expect(background.getCharacteristic('Hue')).toBeDefined()
+    expect(main.getCharacteristic('Saturation')).toBeDefined()
+    expect(background.getCharacteristic('Saturation')).toBeDefined()
+    expect(device.service.testCharacteristic('SwingMode')).toBe(false)
+    expect(device.speedSteps).toBe(6)
+    expect(getDeviceCapabilities('H1310').awsBrightnessNoScale).toBe(true)
+  })
 })
+
+function discoverService(accessory, name) {
+  return accessory.getService(name) || accessory.getServiceById?.(accessory.api.hap.Service.Lightbulb, name)
+}

--- a/lib/device/fan-H7105.js
+++ b/lib/device/fan-H7105.js
@@ -75,7 +75,15 @@ export default class extends GoveeDevice {
         unit: 'unitless', // This is actually from HAP for Bluetooth LE Specification, but fits
       })
       .onSet(async value => this.internalSpeedUpdate(value))
-    this.cacheSpeed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+
+    // cacheSpeed holds a device speed step everywhere else, but the restored
+    // characteristic is a HomeKit percentage, so it has to be converted back.
+    // Left as a percentage it would sometimes equal a real step and silently
+    // swallow the first speed the owner asked for. A restored 100% stays
+    // ambiguous between auto and top speed - both report 100 - so it settles on
+    // top speed rather than guessing.
+    const restoredPercent = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+    this.cacheSpeed = restoredPercent ? hkPercentToFanSpeed(restoredPercent, this.speedSteps) : 0
 
     // Add the set handler to the fan swing mode
     this.service

--- a/lib/device/fan-H7107.js
+++ b/lib/device/fan-H7107.js
@@ -75,7 +75,15 @@ export default class extends GoveeDevice {
         unit: 'unitless', // This is actually from HAP for Bluetooth LE Specification, but fits
       })
       .onSet(async value => this.internalSpeedUpdate(value))
-    this.cacheSpeed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+
+    // cacheSpeed holds a device speed step everywhere else, but the restored
+    // characteristic is a HomeKit percentage, so it has to be converted back.
+    // Left as a percentage it would sometimes equal a real step and silently
+    // swallow the first speed the owner asked for. A restored 100% stays
+    // ambiguous between auto and top speed - both report 100 - so it settles on
+    // top speed rather than guessing.
+    const restoredPercent = this.service.getCharacteristic(this.hapChar.RotationSpeed).value
+    this.cacheSpeed = restoredPercent ? hkPercentToFanSpeed(restoredPercent, this.speedSteps) : 0
 
     // Add the set handler to the fan swing mode
     this.service

--- a/lib/device/index.js
+++ b/lib/device/index.js
@@ -10,6 +10,7 @@ import {
 import deviceCoolerSingle from './cooler-single.js'
 import deviceDehumidifierH7150 from './dehumidifier-H7150.js'
 import deviceDiffuserH7161 from './diffuser-H7161.js'
+import deviceFanH1310 from './fan-H1310.js'
 import deviceFanH1370 from './fan-H1370.js'
 import deviceFanH7100 from './fan-H7100.js'
 import deviceFanH7105 from './fan-H7105.js'
@@ -60,15 +61,9 @@ export default {
   deviceDehumidifierBasic,
   deviceDiffuserBasic,
   deviceFanBasic,
-  // Ceiling fans, not tower fans. They were on the H7100 tower fan handler,
-  // which is a different product entirely: Govee's own app files them under
-  // Indoor Lighting as "Govee Ceiling Fan", while every H71xx is Air Treatment.
-  // The H7100 handler builds no light at all and speaks the tower fan's speed
-  // codes, so an owner got a fan tile that did nothing, an oscillation control
-  // for a fan that cannot oscillate, and no light (#1352)
-  deviceFanH1310: deviceFanH1370,
+  deviceFanH1310,
   deviceFanH1370,
-  deviceFanR1310: deviceFanH1370, // R1310 is the newer naming of the H1310
+  deviceFanR1310: deviceFanH1310, // R1310 is the newer naming of the H1310
   deviceFanH7100,
   deviceFanH7102: deviceFanH7100, // identical to the H7100
   deviceFanH7106: deviceFanH7100, // identical to the H7100

--- a/lib/device/index.js
+++ b/lib/device/index.js
@@ -60,9 +60,15 @@ export default {
   deviceDehumidifierBasic,
   deviceDiffuserBasic,
   deviceFanBasic,
-  deviceFanH1310: deviceFanH7100, // same fan, minus a confirmed swing status message
+  // Ceiling fans, not tower fans. They were on the H7100 tower fan handler,
+  // which is a different product entirely: Govee's own app files them under
+  // Indoor Lighting as "Govee Ceiling Fan", while every H71xx is Air Treatment.
+  // The H7100 handler builds no light at all and speaks the tower fan's speed
+  // codes, so an owner got a fan tile that did nothing, an oscillation control
+  // for a fan that cannot oscillate, and no light (#1352)
+  deviceFanH1310: deviceFanH1370,
   deviceFanH1370,
-  deviceFanR1310: deviceFanH7100, // R1310 is the newer naming of the H1310
+  deviceFanR1310: deviceFanH1370, // R1310 is the newer naming of the H1310
   deviceFanH7100,
   deviceFanH7102: deviceFanH7100, // identical to the H7100
   deviceFanH7106: deviceFanH7100, // identical to the H7100

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1217,6 +1217,23 @@ export default class {
       if (attempted) {
         throw updateFailureError(lastError, platformLang.noConnMethod)
       }
+
+      // Nothing was tried, because every connection this command can travel on
+      // is switched off for this device. Returning true here would tell HomeKit
+      // the command worked, leaving the tile showing a state the device was
+      // never asked for - the failure looks exactly like a device that ignored
+      // us. An OpenAPI-only command reaches this on an account with no api key,
+      // which is how it was found (#1352)
+      if (data.lanParams || data.awsParams || data.openApiParams) {
+        const routes = [
+          data.lanParams && 'lan',
+          data.awsParams && 'aws',
+          data.openApiParams && 'openapi',
+        ].filter(Boolean).join(', ')
+        accessory.logWarn(`${platformLang.devNotUpdated} ${platformLang.noConnMethod} [${routes}]`)
+        throw updateFailureError(lastError, platformLang.noConnMethod)
+      }
+
       return true
     }
 

--- a/lib/utils/command-builder.test.js
+++ b/lib/utils/command-builder.test.js
@@ -121,6 +121,11 @@ describe('what goes out over AWS', () => {
     // H1250: scaling sent a 100% HomeKit write out as 254, and the device came
     // out visibly dimmer than the Govee app's own 100% - confirmed on hardware
     expect(buildCommand({ cmd: 'brightness', value: 100 }, { gvModel: 'H1250' }).awsParams.data.val).toBe(100)
+    // H1310/R1310: its owner's log in #1352 shows the device clamping anything
+    // over 100 - 43% went out as 109 and came back as 100, then rescaling that
+    // echo displayed 39%
+    expect(buildCommand({ cmd: 'brightness', value: 43 }, { gvModel: 'H1310' }).awsParams.data.val).toBe(43)
+    expect(buildCommand({ cmd: 'brightness', value: 100 }, { gvModel: 'R1310' }).awsParams.data.val).toBe(100)
   })
 
   it('uses the odd on and off values the plugs need', () => {

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -40,6 +40,13 @@ const modelOverrides = {
   H8121: { iceSizeAscending: true },
   H8122: { iceSizeAscending: true },
 
+  // The H1310 shares the H1370's ceiling fan handler but is a different
+  // product - Govee's own catalogue gives it goodsType 359 against the
+  // H1370's 368. Its owner reports six fan speeds in the app rather than
+  // twelve, so the two need separate scales (#1352)
+  H1310: { fanSpeedSteps: 6 },
+  R1310: { fanSpeedSteps: 6 },
+
   // AWS outlet uses 17/16 for on/off instead of 1/0
   H5080: { awsPowerOn: 17, awsPowerOff: 16 },
   H5083: { awsPowerOn: 17, awsPowerOff: 16 },
@@ -130,6 +137,9 @@ const defaults = {
   awsBrightnessNoScale: false,
   readsSwingStatus: true,
   iceSizeAscending: false,
+  // Ceiling fan speed steps. 12 is what the H1370 reports, from a real
+  // device's status in #1307
+  fanSpeedSteps: 12,
   // false for the great majority of models, which take the plain 20-byte frame.
   // 'v2' selects the AES-128-GCM transport in ble-crypto.js.
   bleEncryption: false,

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -43,9 +43,17 @@ const modelOverrides = {
   // The H1310 shares the H1370's ceiling fan handler but is a different
   // product - Govee's own catalogue gives it goodsType 359 against the
   // H1370's 368. Its owner reports six fan speeds in the app rather than
-  // twelve, so the two need separate scales (#1352)
-  H1310: { fanSpeedSteps: 6 },
-  R1310: { fanSpeedSteps: 6 },
+  // twelve, so the two need separate scales (#1352). The api confirms it and is
+  // now read first, leaving these as the fallback.
+  //
+  // It also takes brightness on the 0-100 scale rather than 0-254, the same as
+  // the H1250 below. Proven from the same owner's log: sent values above 100
+  // came back clamped (109, 168 and 165 all echoed as 100) while values below
+  // it echoed unchanged (89 -> 89, 97 -> 97, 23 -> 23), and rescaling that 100
+  // on the way back in showed 39% - the identical symptom the H1250 was
+  // diagnosed from
+  H1310: { fanSpeedSteps: 6, awsBrightnessNoScale: true },
+  R1310: { fanSpeedSteps: 6, awsBrightnessNoScale: true },
 
   // AWS outlet uses 17/16 for on/off instead of 1/0
   H5080: { awsPowerOn: 17, awsPowerOff: 16 },

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -40,8 +40,9 @@ const modelOverrides = {
   // evidence needed to turn this on. The H1310 and R1310 also report AWS
   // brightness on a 0-100 scale rather than the usual 0-254 range, so the
   // model-specific override must skip the normal rescale.
-  H1310: { readsSwingStatus: false, awsBrightnessNoScale: true },
-  R1310: { readsSwingStatus: false, awsBrightnessNoScale: true },
+  H1310: { readsSwingStatus: false, awsBrightnessNoScale: true, fanSpeedSteps: 6 },
+  H1370: { fanSpeedSteps: 12 },
+  R1310: { readsSwingStatus: false, awsBrightnessNoScale: true, fanSpeedSteps: 6 },
 
   // Later ice makers number their ice sizes the natural way round. The older
   // ones run the other way, small being the highest byte, so the two families

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -34,26 +34,20 @@ const modelOverrides = {
   // and only the brightness scale is fixed here (#1332)
   H6102: { bleBrightnessScale: 0x64 },
 
+  // The H1310's oscillation status message has never been confirmed to mean
+  // the same thing, so reading it back stays off. While it is off, an owner's
+  // fan reporting one produces a line in the log saying so - which is the
+  // evidence needed to turn this on. The H1310 and R1310 also report AWS
+  // brightness on a 0-100 scale rather than the usual 0-254 range, so the
+  // model-specific override must skip the normal rescale.
+  H1310: { readsSwingStatus: false, awsBrightnessNoScale: true },
+  R1310: { readsSwingStatus: false, awsBrightnessNoScale: true },
+
   // Later ice makers number their ice sizes the natural way round. The older
   // ones run the other way, small being the highest byte, so the two families
   // share a handler and differ only here
   H8121: { iceSizeAscending: true },
   H8122: { iceSizeAscending: true },
-
-  // The H1310 shares the H1370's ceiling fan handler but is a different
-  // product - Govee's own catalogue gives it goodsType 359 against the
-  // H1370's 368. Its owner reports six fan speeds in the app rather than
-  // twelve, so the two need separate scales (#1352). The api confirms it and is
-  // now read first, leaving these as the fallback.
-  //
-  // It also takes brightness on the 0-100 scale rather than 0-254, the same as
-  // the H1250 below. Proven from the same owner's log: sent values above 100
-  // came back clamped (109, 168 and 165 all echoed as 100) while values below
-  // it echoed unchanged (89 -> 89, 97 -> 97, 23 -> 23), and rescaling that 100
-  // on the way back in showed 39% - the identical symptom the H1250 was
-  // diagnosed from
-  H1310: { fanSpeedSteps: 6, awsBrightnessNoScale: true },
-  R1310: { fanSpeedSteps: 6, awsBrightnessNoScale: true },
 
   // AWS outlet uses 17/16 for on/off instead of 1/0
   H5080: { awsPowerOn: 17, awsPowerOff: 16 },
@@ -145,9 +139,6 @@ const defaults = {
   awsBrightnessNoScale: false,
   readsSwingStatus: true,
   iceSizeAscending: false,
-  // Ceiling fan speed steps. 12 is what the H1370 reports, from a real
-  // device's status in #1307
-  fanSpeedSteps: 12,
   // false for the great majority of models, which take the plain 20-byte frame.
   // 'v2' selects the AES-128-GCM transport in ble-crypto.js.
   bleEncryption: false,

--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -34,13 +34,6 @@ const modelOverrides = {
   // and only the brightness scale is fixed here (#1332)
   H6102: { bleBrightnessScale: 0x64 },
 
-  // The H1310 ceiling fan shares the H7100's handler, but its oscillation
-  // status message has never been confirmed to mean the same thing, so reading
-  // it back stays off. While it is off, an owner's fan reporting one produces a
-  // line in the log saying so - which is the evidence needed to turn this on
-  H1310: { readsSwingStatus: false },
-  R1310: { readsSwingStatus: false },
-
   // Later ice makers number their ice sizes the natural way round. The older
   // ones run the other way, small being the highest byte, so the two families
   // share a handler and differ only here

--- a/lib/utils/device-context.js
+++ b/lib/utils/device-context.js
@@ -203,6 +203,18 @@ export function applyDeviceContext(platform, accessory, device, deviceConf, join
       device.openApiInfo.category || 'unknown',
       instances.join(', ') || 'none',
     )
+
+    // The names alone say a capability exists, not what it accepts. A mode
+    // lists its options, a range gives its bounds - and those are the numbers
+    // that otherwise have to be guessed from a model's paperwork or asked of
+    // its owner, one device support request at a time. So print the lot.
+    if (instances.length > 0) {
+      platform.log.debug(
+        '[%s] openapi capability detail %s.',
+        accessory.displayName,
+        JSON.stringify(accessory.context.openApiCapabilities),
+      )
+    }
   }
 
   // Create the instance for this device type

--- a/lib/utils/device-context.test.js
+++ b/lib/utils/device-context.test.js
@@ -156,6 +156,57 @@ describe('what the device tells us about itself', () => {
     expect(Object.keys(accessory.context.openApiCapabilities)).toEqual(['powerSwitch', 'sensorHumidity'])
   })
 
+  /**
+   * The capability names alone say a control exists, not what it accepts. An
+   * H1310 ceiling fan advertises `fanSpeedMode`, and only the options inside it
+   * say how many speeds that particular fan has - which was otherwise a
+   * question to its owner, once per model (#1352).
+   */
+  it('logs what each capability accepts, not only that it exists', () => {
+    const debugged = []
+    apply({
+      platform: {
+        log: Object.assign(() => {}, {
+          warn: () => {},
+          debugWarn: () => {},
+          debug: (...args) => debugged.push(args.map(String).join(' ')),
+        }),
+      },
+      device: {
+        openApiInfo: {
+          category: 'devices.types.light',
+          byInstance: {
+            fanSpeedMode: {
+              type: 'devices.capabilities.mode',
+              instance: 'fanSpeedMode',
+              parameters: { options: [{ name: 'gear1', value: 1 }, { name: 'gear6', value: 6 }] },
+            },
+          },
+        },
+      },
+    })
+
+    const said = debugged.join('\n')
+    expect(said).toContain('fanSpeedMode')
+    expect(said).toContain('gear6')
+  })
+
+  it('says nothing extra when the api listed no capabilities', () => {
+    const debugged = []
+    apply({
+      platform: {
+        log: Object.assign(() => {}, {
+          warn: () => {},
+          debugWarn: () => {},
+          debug: (...args) => debugged.push(args.map(String).join(' ')),
+        }),
+      },
+      device: { openApiInfo: { byInstance: {} } },
+    })
+
+    expect(debugged.filter(line => line.includes('capability detail'))).toHaveLength(0)
+  })
+
   it('shrugs off a broken extras blob rather than failing the whole device', () => {
     const run = () => apply({ device: { httpInfo: { deviceExt: { extResources: 'not json' } } } })
 

--- a/lib/utils/functions.js
+++ b/lib/utils/functions.js
@@ -132,6 +132,30 @@ function hkPercentToFanSpeed(percent, steps) {
 }
 
 /**
+ * How many speed steps a fan really has.
+ *
+ * Govee's api lists a fan's speeds per device, in `fanSpeedMode`, so a device
+ * that reports them is the best source there is - it is right for a model
+ * nobody has written down, and right when two models share a handler. The H1310
+ * and the H1370 do exactly that and have six speeds and twelve (#1352).
+ *
+ * The option VALUE is what goes on the wire, so the scale is the largest value
+ * offered rather than the number of options. `fallback` is the model table, for
+ * a device the api says nothing about - a bluetooth-only fan, or an account
+ * without api access.
+ */
+function fanSpeedStepsFrom(openApiCapabilities, fallback) {
+  const options = openApiCapabilities?.fanSpeedMode?.parameters?.options
+  if (!Array.isArray(options)) {
+    return fallback
+  }
+  const steps = options
+    .map(option => Number(option?.value))
+    .filter(value => Number.isInteger(value) && value > 0)
+  return steps.length > 0 ? Math.max(...steps) : fallback
+}
+
+/**
  * Convert a device speed step into a HomeKit RotationSpeed percentage.
  *
  * When the device reports auto, HomeKit is shown 100%, but callers should keep
@@ -192,6 +216,7 @@ export {
   base64ToHex,
   cenToFar,
   describeControlFailure,
+  fanSpeedStepsFrom,
   fanSpeedToHkPercent,
   farToCen,
   generateCodeFromHexValues,

--- a/test/fan-speed-cache.test.js
+++ b/test/fan-speed-cache.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import deviceFanH1370 from '../lib/device/fan-H1370.js'
+import deviceFanH7100 from '../lib/device/fan-H7100.js'
+import deviceFanH7105 from '../lib/device/fan-H7105.js'
+import deviceFanH7107 from '../lib/device/fan-H7107.js'
+import { makeAccessory, makePlatform } from './harness.js'
+
+/**
+ * The four fans that map HomeKit percentages onto real speed steps keep
+ * `cacheSpeed` as a step - 1 to 8, or 1 to 12 - everywhere except in their
+ * constructors, which seeded it straight from the restored RotationSpeed
+ * characteristic. That characteristic is a percentage.
+ *
+ * Most of the time the two just disagree harmlessly. The exception is a
+ * twelve step fan left running on speed 1: HomeKit stores that as 8%, the
+ * cache reads 8 as though it were a speed, and the next time the owner asks
+ * for speed 8 the handler decides nothing has changed and sends nothing. The
+ * fan stays on speed 1 and Home shows 67%.
+ */
+
+const FANS = [
+  { name: 'H7100', Handler: deviceFanH7100, steps: 8 },
+  { name: 'H7105', Handler: deviceFanH7105, steps: 12 },
+  { name: 'H7107', Handler: deviceFanH7107, steps: 12 },
+  { name: 'H1370', Handler: deviceFanH1370, steps: 12 },
+]
+
+/**
+ * An accessory as Homebridge hands it back after a restart, with the fan
+ * service already built and RotationSpeed holding the percentage from last
+ * time. The props matter: each handler rebuilds the service from scratch if
+ * they look like an older scale, which would throw the restored value away.
+ */
+function makeRestoredAccessory(model, restoredPercent) {
+  const accessory = makeAccessory(model)
+  const service = accessory.addService('Fanv2')
+  const speed = service.getCharacteristic('RotationSpeed')
+  speed.setProps({ maxValue: 100, minStep: 1, minValue: 0, unit: 'unitless' })
+  speed.value = restoredPercent
+  return accessory
+}
+
+function build(Handler, accessory) {
+  const sent = []
+  const platform = makePlatform({
+    sendDeviceUpdate: async (_accessory, params) => {
+      sent.push(params)
+    },
+  })
+  return { device: new Handler(platform, accessory), sent }
+}
+
+describe('the fan speed cache', () => {
+  it.each(FANS)('restores the $name cache as a speed step, not a percentage', ({ name, Handler, steps }) => {
+    // half speed, whatever that is on this fan
+    const half = Math.round(steps / 2)
+    const { device } = build(Handler, makeRestoredAccessory(name, Math.round((half / steps) * 100)))
+
+    expect(device.cacheSpeed).toBe(half)
+  })
+
+  it.each(FANS)('leaves the $name cache at zero when the fan was off', ({ name, Handler }) => {
+    const { device } = build(Handler, makeRestoredAccessory(name, 0))
+
+    // 0 is not a speed step, and converting it would clamp it up to 1 - which
+    // would then swallow a request for the fan's slowest speed
+    expect(device.cacheSpeed).toBe(0)
+  })
+
+  /**
+   * The failure an owner would actually notice, on the twelve step fans. The
+   * eight and six step fans cannot reach it: no percentage they store is also
+   * a valid step number for them.
+   */
+  it.each(FANS.filter(fan => fan.steps === 12))(
+    'still sends an $name speed the owner asks for after a restart on speed 1',
+    async ({ name, Handler }) => {
+      // speed 1 on a twelve step fan is stored by HomeKit as 8%
+      const { device, sent } = build(Handler, makeRestoredAccessory(name, 8))
+
+      // 67% is speed 8 - the same number as the stored percentage
+      await device.internalSpeedUpdate(67)
+
+      expect(sent).toHaveLength(1)
+      expect(device.cacheSpeed).toBe(8)
+    },
+  )
+})

--- a/test/model-snapshot.txt
+++ b/test/model-snapshot.txt
@@ -113,14 +113,22 @@ H12D0 (rgb)
     Saturation
 
 H1310 (fan)
-  handler: GoveeFanH1370
+  handler: GoveeFanH1310
   service: Fanv2
     Active
     RotationSpeed  [maxValue=100, minStep=1, minValue=0, unit="unitless"]
-  service: Lightbulb
-    Brightness
-    ColorTemperature  [maxValue=370, minValue=154]
+  service: Lightbulb (Background Light)
+    Brightness  [minStep=1]
+    ColorTemperature
+    Hue
     On
+    Saturation
+  service: Lightbulb (Main Light)
+    Brightness  [minStep=1]
+    ColorTemperature
+    Hue
+    On
+    Saturation
 
 H1370 (fan)
   handler: GoveeFanH1370
@@ -5269,14 +5277,22 @@ R1250 (rgb)
     Saturation
 
 R1310 (fan)
-  handler: GoveeFanH1370
+  handler: GoveeFanH1310
   service: Fanv2
     Active
     RotationSpeed  [maxValue=100, minStep=1, minValue=0, unit="unitless"]
-  service: Lightbulb
-    Brightness
-    ColorTemperature  [maxValue=370, minValue=154]
+  service: Lightbulb (Background Light)
+    Brightness  [minStep=1]
+    ColorTemperature
+    Hue
     On
+    Saturation
+  service: Lightbulb (Main Light)
+    Brightness  [minStep=1]
+    ColorTemperature
+    Hue
+    On
+    Saturation
 
 R1401 (rgb)
   handler: deviceLight

--- a/test/model-snapshot.txt
+++ b/test/model-snapshot.txt
@@ -113,14 +113,17 @@ H12D0 (rgb)
     Saturation
 
 H1310 (fan)
-  handler: GoveeFanH7100
+  handler: GoveeFanH1370
   service: Fanv2
     Active
     RotationSpeed  [maxValue=100, minStep=1, minValue=0, unit="unitless"]
-    SwingMode
+  service: Lightbulb
+    Brightness
+    ColorTemperature  [maxValue=370, minValue=154]
+    On
 
 H1370 (fan)
-  handler: deviceFanH1370
+  handler: GoveeFanH1370
   service: Fanv2
     Active
     RotationSpeed  [maxValue=100, minStep=1, minValue=0, unit="unitless"]
@@ -5266,11 +5269,14 @@ R1250 (rgb)
     Saturation
 
 R1310 (fan)
-  handler: GoveeFanH7100
+  handler: GoveeFanH1370
   service: Fanv2
     Active
     RotationSpeed  [maxValue=100, minStep=1, minValue=0, unit="unitless"]
-    SwingMode
+  service: Lightbulb
+    Brightness
+    ColorTemperature  [maxValue=370, minValue=154]
+    On
 
 R1401 (rgb)
   handler: deviceLight

--- a/test/send-no-connection.test.js
+++ b/test/send-no-connection.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import GoveePlatform from '../lib/platform.js'
+
+/**
+ * A command that can only travel one way, on a connection the device does not
+ * have enabled, used to report success.
+ *
+ * `sendDeviceUpdate` tries LAN, then AWS, then OpenAPI, and falls through to
+ * bluetooth. A command built for one route only - `cmd: 'openApi'` produces
+ * `openApiParams` and nothing else - skipped every branch when that route was
+ * off, reached the bluetooth fall-through with no bluetooth frame to send, and
+ * returned true having sent nothing at all.
+ *
+ * HomeKit takes that as done and leaves the tile showing a state the device was
+ * never asked for. It looks identical to a device ignoring the command, which
+ * is the hardest kind of fault to report and the hardest to believe. Found
+ * while wiring the H1310's two lights to their own api toggles (#1352), which
+ * only exist over OpenAPI.
+ */
+
+function accessoryWithout(...disabled) {
+  const context = {
+    gvModel: 'H1310',
+    gvDeviceId: 'AA:BB',
+    useLanControl: true,
+    useAwsControl: true,
+    useOpenApiControl: true,
+    useBleControl: true,
+  }
+  disabled.forEach((key) => {
+    context[key] = false
+  })
+  return {
+    displayName: 'Master Ceiling Fan',
+    context,
+    log: () => {},
+    logWarn: () => {},
+    logDebug: () => {},
+  }
+}
+
+// A per-light toggle, which the H1310 only accepts over the api
+const PER_LIGHT = {
+  cmd: 'openApi',
+  openApi: {
+    instance: 'mainLightToggle',
+    capabilityType: 'devices.capabilities.toggle',
+    value: 1,
+  },
+}
+
+function platformWith(overrides = {}) {
+  return Object.assign(Object.create(GoveePlatform.prototype), {
+    lanClient: { updateDevice: async () => {} },
+    awsClient: { updateDevice: async () => {} },
+    openApiClient: { updateDevice: async () => {} },
+    bleClient: { updateDevice: async () => {} },
+    queue: { add: async fn => fn() },
+    ...overrides,
+  })
+}
+
+describe('sending a command with no connection to send it on', () => {
+  it('refuses an api-only command when the device has no api control', async () => {
+    const platform = platformWith()
+
+    await expect(platform.sendDeviceUpdate(accessoryWithout('useOpenApiControl'), PER_LIGHT))
+      .rejects
+      .toThrow()
+  })
+
+  it('says which route the command needed', async () => {
+    const said = []
+    const accessory = accessoryWithout('useOpenApiControl')
+    accessory.logWarn = message => said.push(String(message))
+
+    await platformWith().sendDeviceUpdate(accessory, PER_LIGHT).catch(() => {})
+
+    expect(said.join(' ')).toContain('openapi')
+  })
+
+  it('still sends the same command when api control is on', async () => {
+    const sent = []
+    const platform = platformWith({
+      openApiClient: { updateDevice: async (_accessory, params) => sent.push(params) },
+    })
+
+    await expect(platform.sendDeviceUpdate(accessoryWithout(), PER_LIGHT)).resolves.toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(sent[0].instance).toBe('mainLightToggle')
+  })
+})


### PR DESCRIPTION
## Summary
- route the H1310/R1310 ceiling fan away from the tower-fan handler
- keep oscillation off for the H1310 family, since it does not support that feature
- add dedicated H1310 light tiles for the main and background lights with full colour access
- keep the fan on the correct 6-step scale and the lights on the model’s accepted 0-100 brightness range

## Testing
- `npm test -- --run lib/device/fan-H7100.test.js`
- passed (4/4)