### PR TITLE
fix: H601A, H601B and H6010 take 0-100 brightness over AWS

### DIFF
--- a/lib/utils/device-capabilities.js
+++ b/lib/utils/device-capabilities.js
@@ -99,6 +99,14 @@ const modelOverrides = {
   H1401: { awsBrightnessNoScale: true },
   H6008: { awsBrightnessNoScale: true },
   H6022: { awsBrightnessNoScale: true },
+  // H601A / H601B strips and H6010 bulbs, seen on one bridge with 119 of them: with the
+  // scaling on, a 100% send lands the lights at about 5% and 37% lands them at full, and the
+  // AWS status echo reports 5% after a full-brightness command. `awsBrightnessNoScale` per
+  // device brings every send and echo back to the requested value. LAN is not reachable on
+  // that network, so every command there goes over AWS
+  H601A: { awsBrightnessNoScale: true },
+  H601B: { awsBrightnessNoScale: true },
+  H6010: { awsBrightnessNoScale: true },
 
   // H1250: proven live on hardware 2026-08-08 - a HomeKit write of 100 sent
   // val:254 and came out visibly dimmer than the Govee app's own 100%, then the


### PR DESCRIPTION
Adds **H601A**, **H601B** and **H6010** to the `awsBrightnessNoScale` model table, the same treatment H1401 / H6008 / H6022 got in #1321.

With the AWS 0-254 scaling applied, a 100% command lands these lights at about 5% and the status echo reports 5%; 37% lands them at full. Setting `awsBrightnessNoScale` per device (verified on 119 lights: 110 H601A, 4 H601B, 5 H6010, firmware 1.00.13) brings every send and echo back to the requested value.

Fixes #1364
